### PR TITLE
Fix deprecated use of self.config_entry in OptionsFlowHandler

### DIFF
--- a/custom_components/robovac/config_flow.py
+++ b/custom_components/robovac/config_flow.py
@@ -218,7 +218,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handles options flow for the component."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         self.selected_vacuum = None
 
     async def async_step_init(self, user_input=None):


### PR DESCRIPTION
### Changes:
- Replaced deprecated direct assignment of `self.config_entry` in `OptionsFlowHandler` with the updated approach, assigning the `config_entry` to a private attribute `_config_entry`.

### Testing:

**Tested on Home Assistant version 2025.1.4**

Core: 2025.1.4
Supervisor: 2025.02.0
Operating System: 14.2
Frontend: 20250109.2

- Verified no warnings related to `self.config_entry`.
- Integration functions as expected.

### Related Issues:
- **Issue #99**: Eufy RoboVac G50 integration – Deprecation warning related to `self.config_entry`.
- **Issue #108**: Does not work with Home Assistant 2025.12 – Deprecation warning related to `self.config_entry`.

Fixes #108
